### PR TITLE
Fixing issue with CCTP to multiple domains and MemoryOOG work around

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Filter directories
         run: |
           sudo apt update && sudo apt install -y lcov
-          lcov --remove lcov.info 'test/*' --output-file lcov.info --rc lcov_branch_coverage=1
+          lcov --remove lcov.info 'test/*' 'src/testing/*' --output-file lcov.info --rc lcov_branch_coverage=1
 
       # This step posts a detailed coverage report as a comment and deletes previous comments on
       # each push. The below step is used to fail coverage if the specified coverage threshold is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Filter directories
         run: |
           sudo apt update && sudo apt install -y lcov
-          lcov --remove lcov.info 'test/*' 'script/*' 'src/testing/*' --output-file lcov.info --rc lcov_branch_coverage=1
+          lcov --remove lcov.info 'test/*' --output-file lcov.info --rc lcov_branch_coverage=1
 
       # This step posts a detailed coverage report as a comment and deletes previous comments on
       # each push. The below step is used to fail coverage if the specified coverage threshold is

--- a/src/testing/utils/RecordedLogs.sol
+++ b/src/testing/utils/RecordedLogs.sol
@@ -33,6 +33,11 @@ library RecordedLogs {
         return logs;
     }
 
+    function clearLogs() internal {
+        vm.getRecordedLogs();
+        vm.serializeJson("RECORDED_LOGS", "{}");
+    }
+
     function ingestAndFilterLogs(Bridge storage bridge, bool sourceToDestination, bytes32 topic0, bytes32 topic1, address emitter) internal returns (Vm.Log[] memory filteredLogs) {
         Vm.Log[] memory logs = RecordedLogs.getLogs();
         uint256 lastIndex = sourceToDestination ? bridge.lastSourceLogIndex : bridge.lastDestinationLogIndex;

--- a/test/CircleCCTPIntegration.t.sol
+++ b/test/CircleCCTPIntegration.t.sol
@@ -60,12 +60,11 @@ contract CircleCCTPIntegrationTest is IntegrationBaseTest {
         destinationDomainId = CCTPForwarder.DOMAIN_ID_CIRCLE_OPTIMISM;
         initBaseContracts(getChain("optimism").createFork());
 
-        vm.startPrank(randomAddress);
-        queueSourceToDestination(abi.encodeCall(MessageOrdering.push, (1)));
-        vm.stopPrank();
+        destination.selectFork();
 
+        vm.prank(bridge.destinationCrossChainMessenger);
         vm.expectRevert("CCTPReceiver/invalid-sourceAuthority");
-        relaySourceToDestination();
+        CCTPReceiver(destinationReceiver).handleReceiveMessage(0, bytes32(uint256(uint160(randomAddress))), abi.encodeCall(MessageOrdering.push, (1)));
     }
 
     function test_avalanche() public {

--- a/test/CircleCCTPIntegration.t.sol
+++ b/test/CircleCCTPIntegration.t.sol
@@ -21,16 +21,6 @@ contract DummyReceiver {
     
 }
 
-contract LogGenerator {
-
-    event DummyEvent();
-
-    function makeLogs(uint256 num) external {
-        for (uint256 i = 0; i < num; i++) emit DummyEvent();
-    }
-
-}
-
 contract CircleCCTPIntegrationTest is IntegrationBaseTest {
 
     using CCTPBridgeTesting for *;
@@ -116,35 +106,6 @@ contract CircleCCTPIntegrationTest is IntegrationBaseTest {
         bridge2 = CCTPBridgeTesting.createCircleBridge(source, destination2);
 
         source.selectFork();
-
-        CCTPForwarder.sendMessage(CCTPForwarder.MESSAGE_TRANSMITTER_CIRCLE_ETHEREUM, CCTPForwarder.DOMAIN_ID_CIRCLE_BASE, address(r1), "");
-        CCTPForwarder.sendMessage(CCTPForwarder.MESSAGE_TRANSMITTER_CIRCLE_ETHEREUM, CCTPForwarder.DOMAIN_ID_CIRCLE_ARBITRUM_ONE, address(r2), "");
-
-        bridge.relayMessagesToDestination(true);
-        bridge2.relayMessagesToDestination(true);
-    }
-
-    // TODO move this into a RecordedLogs testing file
-    function test_memory_oog() public {
-        destination  = getChain("base").createFork();
-        destination2 = getChain("arbitrum_one").createFork();
-
-        destination.selectFork();
-        DummyReceiver r1 = new DummyReceiver();
-        destination2.selectFork();
-        DummyReceiver r2 = new DummyReceiver();
-
-        bridge  = CCTPBridgeTesting.createCircleBridge(source, destination);
-        bridge2 = CCTPBridgeTesting.createCircleBridge(source, destination2);
-
-        source.selectFork();
-
-        // Generate a bunch of logs
-        LogGenerator gen = new LogGenerator();
-        gen.makeLogs(1000);
-
-        // Comment this out to see MemoryOOG error
-        RecordedLogs.clearLogs();
 
         CCTPForwarder.sendMessage(CCTPForwarder.MESSAGE_TRANSMITTER_CIRCLE_ETHEREUM, CCTPForwarder.DOMAIN_ID_CIRCLE_BASE, address(r1), "");
         CCTPForwarder.sendMessage(CCTPForwarder.MESSAGE_TRANSMITTER_CIRCLE_ETHEREUM, CCTPForwarder.DOMAIN_ID_CIRCLE_ARBITRUM_ONE, address(r2), "");

--- a/test/RecordedLogs.t.sol
+++ b/test/RecordedLogs.t.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity >=0.8.0;
+
+import "forge-std/Test.sol";
+
+import { CCTPForwarder }         from "src/forwarders/CCTPForwarder.sol";
+import { CCTPBridgeTesting }     from "src/testing/bridges/CCTPBridgeTesting.sol";
+import { Bridge }                from "src/testing/Bridge.sol";
+import { Domain, DomainHelpers } from "src/testing/Domain.sol";
+import { RecordedLogs }          from "src/testing/utils/RecordedLogs.sol";
+
+contract DummyReceiver {
+
+    function handleReceiveMessage(
+        uint32,
+        bytes32,
+        bytes calldata
+    ) external pure returns (bool) {
+        return true;
+    }
+    
+}
+
+contract LogGenerator {
+
+    event DummyEvent();
+
+    function makeLogs(uint256 num) external {
+        for (uint256 i = 0; i < num; i++) emit DummyEvent();
+    }
+
+}
+
+contract RecordedLogsTest is Test {
+
+    using DomainHelpers for *;
+    using CCTPBridgeTesting for *;
+
+    Domain source;
+    Domain destination;
+
+    Bridge bridge;
+
+    function test_memory_oog() public {
+        source      = getChain("mainnet").createFork();
+        destination = getChain("base").createFork();
+
+        bridge = CCTPBridgeTesting.createCircleBridge(source, destination);
+
+        destination.selectFork();
+
+        DummyReceiver r1 = new DummyReceiver();
+
+        source.selectFork();
+
+        // Generate a bunch of logs
+        LogGenerator gen = new LogGenerator();
+        gen.makeLogs(1000);
+
+        // Comment this out to see MemoryOOG error
+        RecordedLogs.clearLogs();
+
+        CCTPForwarder.sendMessage(CCTPForwarder.MESSAGE_TRANSMITTER_CIRCLE_ETHEREUM, CCTPForwarder.DOMAIN_ID_CIRCLE_BASE, address(r1), "");
+
+        bridge.relayMessagesToDestination(true);
+    }
+
+}


### PR DESCRIPTION
Multiple CCTP bridges was broken. It filters based on destination domain now. This is needed now that we are adding Arbitrum to spells repo.

MemoryOOG for RecordedLogs workaround by clearing the logs. Not ideal, but it will work for now.

Please note I also had to tweak the CCTP invalid source authority test because of the `localDomain()` call. The expected revert from before wouldn't work because it thinks the local domain function is where the revert should be.