### PR TITLE
Use transient storage for recordedlogs

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,5 +2,6 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+fs_permissions = [{ access = "read-write", path = "./out"}]
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,6 +2,5 @@
 src = "src"
 out = "out"
 libs = ["lib"]
-fs_permissions = [{ access = "read-write", path = "./out"}]
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/src/testing/bridges/AMBBridgeTesting.sol
+++ b/src/testing/bridges/AMBBridgeTesting.sol
@@ -52,7 +52,7 @@ library AMBBridgeTesting {
     }
 
     function init(Bridge memory bridge) internal returns (Bridge memory) {
-        vm.recordLogs();
+        RecordedLogs.init();
 
          // Set minimum required signatures to zero for both domains
         bridge.destination.selectFork();

--- a/src/testing/bridges/ArbitrumBridgeTesting.sol
+++ b/src/testing/bridges/ArbitrumBridgeTesting.sol
@@ -91,7 +91,7 @@ library ArbitrumBridgeTesting {
     }
 
     function init(Bridge memory bridge) internal returns (Bridge memory) {
-        vm.recordLogs();
+        RecordedLogs.init();
 
         // Need to replace ArbSys contract with custom code to make it compatible with revm
         bridge.destination.selectFork();

--- a/src/testing/bridges/CCTPBridgeTesting.sol
+++ b/src/testing/bridges/CCTPBridgeTesting.sol
@@ -68,7 +68,7 @@ library CCTPBridgeTesting {
             0
         );
 
-        vm.recordLogs();
+        RecordedLogs.init();
 
         return bridge;
     }

--- a/src/testing/bridges/OptimismBridgeTesting.sol
+++ b/src/testing/bridges/OptimismBridgeTesting.sol
@@ -73,7 +73,7 @@ library OptimismBridgeTesting {
     }
 
     function init(Bridge memory bridge) internal returns (Bridge memory) {
-        vm.recordLogs();
+        RecordedLogs.init();
 
         // For consistency with other bridges
         bridge.source.selectFork();

--- a/src/testing/utils/RecordedLogs.sol
+++ b/src/testing/utils/RecordedLogs.sol
@@ -5,37 +5,125 @@ import { Vm } from "forge-std/Vm.sol";
 
 import { Bridge } from "../Bridge.sol";
 
+contract RecordedLogsStorage {
+
+    uint256 public forkId;
+
+    function setForkId(uint256 _forkId) external {
+        forkId = _forkId;
+    }
+
+    function storeBytes(bytes memory data) external {
+        uint256 len = data.length;
+        uint256 chunks = (len + 31) / 32;
+
+        assembly {
+            tstore(0, len)
+        }
+
+        for (uint256 i = 0; i < chunks; i++) {
+            bytes32 chunk;
+            assembly {
+                chunk := mload(add(data, add(32, mul(i, 32))))
+                tstore(add(i, 1), chunk)
+            }
+        }
+    }
+
+    function getBytes() external view returns (bytes memory data) {
+        uint256 len;
+        
+        assembly {
+            len := tload(0)
+        }
+        
+        data = new bytes(len);
+        uint256 chunks = (len + 31) / 32;
+        
+        for (uint256 i = 0; i < chunks; i++) {
+            bytes32 chunk;
+            assembly {
+                chunk := tload(add(i, 1))
+                mstore(add(data, add(32, mul(i, 32))), chunk) // Store chunk into memory
+            }
+        }
+    }
+
+    function clearLogs() external {
+        assembly {
+            tstore(0, 0)
+        }
+    }
+
+}
+
 library RecordedLogs {
 
     Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
+    address private constant STORAGE = address(uint160(uint256(keccak256("__RecordedLogsStorage__"))));
+
+    function init() internal {
+        bytes memory bytecode = vm.getCode("RecordedLogs.sol:RecordedLogsStorage");
+        address deployed;
+        assembly {
+            deployed := create(0, add(bytecode, 0x20), mload(bytecode))
+        }
+        vm.etch(STORAGE, deployed.code);
+        vm.makePersistent(STORAGE);
+        // The fork doesn't really matter we just use this to store the logs on the same place
+        RecordedLogsStorage(STORAGE).setForkId(vm.createFork("https://rpc.ankr.com/eth"));
+
+        vm.recordLogs();
+    }
+
     function getLogs() internal returns (Vm.Log[] memory) {
-        string memory _logs = vm.serializeUint("RECORDED_LOGS", "a", 0); // this is the only way to get the logs from the memory object
-        uint256 count = keccak256(bytes(_logs)) == keccak256('{"a":0}') ? 0 : abi.decode(vm.parseJson(_logs, ".count"), (uint256));
+        bool isActiveFork = false;
+        uint256 prevForkId;
+        try vm.activeFork() returns (uint256 forkId) {
+            prevForkId = forkId;
+            vm.selectFork(RecordedLogsStorage(STORAGE).forkId());
+            isActiveFork = true;
+        } catch {}
 
+        // Fetch new logs
         Vm.Log[] memory newLogs = vm.getRecordedLogs();
-        Vm.Log[] memory logs = new Vm.Log[](count + newLogs.length);
-        for (uint256 i = 0; i < count; i++) {
-            bytes memory data = vm.parseJson(_logs, string(abi.encodePacked(".", vm.toString(i), "_", "data")));
-            logs[i].data = data.length > 32 ? abi.decode(data, (bytes)) : data;
-            logs[i].topics  = abi.decode(vm.parseJson(_logs, string(abi.encodePacked(".", vm.toString(i), "_", "topics"))), (bytes32[]));
-            logs[i].emitter = abi.decode(vm.parseJson(_logs, string(abi.encodePacked(".", vm.toString(i), "_", "emitter"))), (address));
+
+        // Decode the old logs from storage
+        Vm.Log[] memory oldLogs;
+        bytes memory oldEncodedLogsBytes = RecordedLogsStorage(STORAGE).getBytes();
+        if (oldEncodedLogsBytes.length > 0) {
+            bytes[] memory oldEncodedLogs = abi.decode(oldEncodedLogsBytes, (bytes[]));
+            oldLogs = new Vm.Log[](oldEncodedLogs.length);
+            for (uint256 i = 0; i < oldEncodedLogs.length; i++) {
+                (oldLogs[i].topics, oldLogs[i].data, oldLogs[i].emitter) = abi.decode(oldEncodedLogs[i], (bytes32[], bytes, address));
+            }
         }
 
-        for (uint256 i = 0; i < newLogs.length; i++) {
-            vm.serializeBytes("RECORDED_LOGS", string(abi.encodePacked(vm.toString(count), "_", "data")), logs[count].data = newLogs[i].data);
-            vm.serializeBytes32("RECORDED_LOGS", string(abi.encodePacked(vm.toString(count), "_", "topics")), logs[count].topics = newLogs[i].topics);
-            vm.serializeAddress("RECORDED_LOGS", string(abi.encodePacked(vm.toString(count), "_", "emitter")), logs[count].emitter = newLogs[i].emitter);
-            count++;
+        // Merge them together
+        Vm.Log[] memory logs = new Vm.Log[](oldLogs.length + newLogs.length);
+        for (uint256 i = 0; i < oldLogs.length; i++) {
+            logs[i] = oldLogs[i];
         }
-        vm.serializeUint("RECORDED_LOGS", "count", count);
+        for (uint256 i = 0; i < newLogs.length; i++) {
+            logs[oldLogs.length + i] = newLogs[i];
+        }
+
+        // Write the combined logs back to storage
+        bytes[] memory encodedLogs = new bytes[](logs.length);
+        for (uint256 i = 0; i < logs.length; i++) {
+            encodedLogs[i] = abi.encode(logs[i].topics, logs[i].data, logs[i].emitter);
+        }
+        RecordedLogsStorage(STORAGE).storeBytes(abi.encode(encodedLogs));
+        
+        if (isActiveFork) vm.selectFork(prevForkId);
 
         return logs;
     }
 
     function clearLogs() internal {
         vm.getRecordedLogs();
-        vm.serializeJson("RECORDED_LOGS", "{}");
+        RecordedLogsStorage(STORAGE).clearLogs();
     }
 
     function ingestAndFilterLogs(Bridge storage bridge, bool sourceToDestination, bytes32 topic0, bytes32 topic1, address emitter) internal returns (Vm.Log[] memory filteredLogs) {

--- a/test/ArbitrumIntegration.t.sol
+++ b/test/ArbitrumIntegration.t.sol
@@ -25,12 +25,10 @@ contract ArbitrumIntegrationTest is IntegrationBaseTest {
     function test_invalidSourceAuthority() public {
         initBaseContracts(getChain("arbitrum_one").createFork());
 
-        vm.startPrank(randomAddress);
-        queueSourceToDestination(abi.encodeCall(MessageOrdering.push, (1)));
-        vm.stopPrank();
-
+        destination.selectFork();
         vm.expectRevert("ArbitrumReceiver/invalid-l1Authority");
-        relaySourceToDestination();
+        vm.prank(randomAddress);
+        MessageOrdering(destinationReceiver).push(1);
     }
 
     function test_arbitrumOne() public {

--- a/test/RecordedLogs.t.sol
+++ b/test/RecordedLogs.t.sol
@@ -11,11 +11,15 @@ import { RecordedLogs }          from "src/testing/utils/RecordedLogs.sol";
 
 contract DummyReceiver {
 
+    bytes public data;
+
     function handleReceiveMessage(
         uint32,
         bytes32,
-        bytes calldata
-    ) external pure returns (bool) {
+        bytes calldata _data
+    ) external returns (bool) {
+        data = _data;
+
         return true;
     }
     
@@ -23,10 +27,16 @@ contract DummyReceiver {
 
 contract LogGenerator {
 
-    event DummyEvent();
+    event DummyEvent(string label, uint256 num);
+
+    string label;
+
+    constructor(string memory _label) {
+        label = _label;
+    }
 
     function makeLogs(uint256 num) external {
-        for (uint256 i = 0; i < num; i++) emit DummyEvent();
+        for (uint256 i = 0; i < num; i++) emit DummyEvent(label, i);
     }
 
 }
@@ -41,7 +51,54 @@ contract RecordedLogsTest is Test {
 
     Bridge bridge;
 
-    function test_memory_oog() public {
+    function setUp() public {
+        RecordedLogs.init();
+    }
+
+    function test_logs_fetch() public {
+        // We use unique label between tests to make sure there is no interference between tests
+        string memory label = "test1";
+        LogGenerator gen = new LogGenerator(label);
+        gen.makeLogs(2);
+
+        Vm.Log[] memory logs = RecordedLogs.getLogs();
+
+        assertEq(logs.length, 2);
+        assertEq(logs[0].data, abi.encode(label, 0));
+        assertEq(logs[1].data, abi.encode(label, 1));
+    }
+
+    function test_logs_persists() public {
+        string memory label = "test2";
+        LogGenerator gen = new LogGenerator(label);
+        gen.makeLogs(1);
+
+        Vm.Log[] memory logs = RecordedLogs.getLogs();
+
+        assertEq(logs.length, 1);
+        assertEq(logs[0].data, abi.encode(label, 0));
+
+        gen.makeLogs(2);
+
+        Vm.Log[] memory logs2 = RecordedLogs.getLogs();
+
+        assertEq(logs2.length, 3);
+        assertEq(logs2[0].data, abi.encode(label, 0));
+        assertEq(logs2[1].data, abi.encode(label, 0));
+        assertEq(logs2[2].data, abi.encode(label, 1));
+    }
+
+    function test_performance() public {
+        // This will generate 1k logs
+        for (uint256 i = 0; i < 10; i++) {
+            LogGenerator gen = new LogGenerator("performance");
+            gen.makeLogs(100);
+            Vm.Log[] memory logs = RecordedLogs.getLogs();
+            assertEq(logs.length, 100 * (i + 1));
+        }
+    }
+
+    function test_multichain() public {
         source      = getChain("mainnet").createFork();
         destination = getChain("base").createFork();
 
@@ -54,15 +111,18 @@ contract RecordedLogsTest is Test {
         source.selectFork();
 
         // Generate a bunch of logs
-        LogGenerator gen = new LogGenerator();
-        gen.makeLogs(1000);
+        LogGenerator gen = new LogGenerator("multichain");
+        gen.makeLogs(10000);
 
-        // Comment this out to see MemoryOOG error
-        RecordedLogs.clearLogs();
+        CCTPForwarder.sendMessage(CCTPForwarder.MESSAGE_TRANSMITTER_CIRCLE_ETHEREUM, CCTPForwarder.DOMAIN_ID_CIRCLE_BASE, address(r1), "123");
 
-        CCTPForwarder.sendMessage(CCTPForwarder.MESSAGE_TRANSMITTER_CIRCLE_ETHEREUM, CCTPForwarder.DOMAIN_ID_CIRCLE_BASE, address(r1), "");
+        destination.selectFork();
+
+        assertEq(r1.data(), bytes(""));
 
         bridge.relayMessagesToDestination(true);
+
+        assertEq(r1.data(), bytes("123"));
     }
 
 }


### PR DESCRIPTION
This fixes the non-deterministic errors we get from using json as well as running out of memory. Transient storage is much more performant.