### PR TITLE
Init should only be called once

### DIFF
--- a/src/testing/utils/RecordedLogs.sol
+++ b/src/testing/utils/RecordedLogs.sol
@@ -64,6 +64,10 @@ library RecordedLogs {
     address private constant STORAGE = address(uint160(uint256(keccak256("__RecordedLogsStorage__"))));
 
     function init() internal {
+        if (STORAGE.code.length > 0) {
+            return;
+        }
+
         bytes memory bytecode = vm.getCode("RecordedLogs.sol:RecordedLogsStorage");
         address deployed;
         assembly {


### PR DESCRIPTION
Small bug where each bridge would init the recorded logs many times which was unnecessary.